### PR TITLE
Hashed keys for memoize, take 2

### DIFF
--- a/flaskext/cache/__init__.py
+++ b/flaskext/cache/__init__.py
@@ -184,8 +184,7 @@ class Cache(object):
                 if rv is None:
                     rv = f(*args, **kwargs)
                     self.cache.set(cache_key, rv, timeout=timeout)
-                    if cache_key not in self._memoized:
-                        self._memoized.append((f.__name__, cache_key))
+                    self._memoized.append((f.__name__, cache_key))
                 return rv
             return decorated_function
         return memoize


### PR DESCRIPTION
Basic md5 hash solution, I moved the function name to Cache._memoized to save the per-function invalidation. It seems to work well on my development server and it passes the unit tests.
