### PR TITLE
Python 2.5 compatibility, plus bugfix

### DIFF
--- a/flaskext/cache/__init__.py
+++ b/flaskext/cache/__init__.py
@@ -180,7 +180,7 @@ class Cache(object):
             def decorated_function(*args, **kwargs):
                 cache_key = hashlib.md5()
                 try:
-                    updated = "{1}{2}{3}".format(f.__name__, args, kwargs)
+                    updated = "{0}{1}{2}".format(f.__name__, args, kwargs)
                 except AttributeError:
                     updated = "%s%s%s" % (f.__name__, args, kwargs)
                 cache_key.update(updated)

--- a/flaskext/cache/__init__.py
+++ b/flaskext/cache/__init__.py
@@ -180,7 +180,7 @@ class Cache(object):
             def decorated_function(*args, **kwargs):
                 cache_key = hashlib.md5()
                 try:
-                    updated = "{1}{1}{1}".format(f.__name__, args, kwargs)
+                    updated = "{1}{2}{3}".format(f.__name__, args, kwargs)
                 except AttributeError:
                     updated = "%s%s%s" % (f.__name__, args, kwargs)
                 cache_key.update(updated)

--- a/flaskext/cache/__init__.py
+++ b/flaskext/cache/__init__.py
@@ -179,7 +179,11 @@ class Cache(object):
             @wraps(f)
             def decorated_function(*args, **kwargs):
                 cache_key = hashlib.md5()
-                cache_key.update("{1}{1}{1}".format(f.__name__, args, kwargs))
+                try:
+                    updated = "{1}{1}{1}".format(f.__name__, args, kwargs)
+                except AttributeError:
+                    updated = "%s%s%s" % (f.__name__, args, kwargs)
+                cache_key.update(updated)
                 cache_key = cache_key.hexdigest()
                 
                 rv = self.cache.get(cache_key)


### PR DESCRIPTION
I'm trying to use flask-cache on App Engine, which is Python 2.5 only. Python 2.5 doesn't support str.format(), so this pull request contains a simple workaround. I also discovered that the code appeared to have a typo bug in it -- I put that in a separate commit. Please review to be sure that the code is doing what's intended.
