### PR TITLE
Memoized delete with optional parameters

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -155,7 +155,18 @@ You can do this with the :meth:`~Cache.delete_memoized` function.::
 	
 .. note::
 
-	You can pass as many function names as you wish to delete_memoized.
+  If only the function name is given as parameter, all the memoized versions
+  of it will be erazed. However, you can delete specific cache by providing the
+  same parameter values as when caching. In following example only the ``user``
+  -roled cache is erased:
+
+  .. code-block:: python
+
+     has_membership('admin')
+     has_membership('user')
+
+     cache.delete_memoized('has_membership', 'user')
+
 
 Custom Cache Backends
 ---------------------

--- a/flaskext/cache/__init__.py
+++ b/flaskext/cache/__init__.py
@@ -195,7 +195,7 @@ class Cache(object):
             return decorated_function
         return memoize
     
-    def delete_memoized(self, *keys, **kwargs):
+    def delete_memoized(self, fname, *args, **kwargs):
         """
         Deletes the specified functions caches, based by given parameters.
         If parameters are given, only the functions that were memoized with them
@@ -233,22 +233,26 @@ class Cache(object):
             47
 
             
-        :param \*keys: A list of positional parameters used with memoized function.
-        :param \*kwargs: A list of named parameters used with memoized function.
+        :param fname: Name of the memoized function.
+        :param \*args: A list of positional parameters used with memoized function.
+        :param \*kwargs: A dict of named parameters used with memoized function.
         """
         def deletes(item):
 
             # If no parameters given, delete all memoized versions of the function
-            # NOTE: first key is the function name
-            if not keys[1:] and not kwargs:
-              if item[0] in keys:
+            if not args and not kwargs:
+              if item[0] == fname:
                 self.cache.delete(item[1])
                 return True
               return False
 
             # Construct the cache key as in memoized function
             cache_key = hashlib.md5()
-            cache_key.update("{1}{1}{1}".format(item[0], keys[1:], kwargs))
+            try:
+                updated = "{0}{1}{2}".format(fname, args, kwargs)
+            except AttributeError:
+                updated = "%s%s%s" % (fname, args, kwargs)
+            cache_key.update(updated)
             cache_key = cache_key.hexdigest()
 
             if item[1] == cache_key:

--- a/test_cache.py
+++ b/test_cache.py
@@ -154,10 +154,32 @@ class CacheTestCase(unittest.TestCase):
             time.sleep(1)
             
             assert big_foo(5, 2) == result
+            assert big_foo(5, 2) == result
+            assert big_foo(5, 3) != result
             
             self.cache.delete_memoized('big_foo')
             
             assert big_foo(5, 2) != result
+
+
+    def test_08_delete_memoize(self):
+
+        with self.app.test_request_context():
+            @self.cache.memoize()
+            def big_foo(a, b):
+                return a+b+random.randrange(0, 100000)
+
+            result_a = big_foo(5, 1)
+            result_b = big_foo(5, 2)
+
+            assert big_foo(5, 1) == result_a
+            assert big_foo(5, 2) == result_b
+
+            self.cache.delete_memoized('big_foo', 5, 2)
+
+            assert big_foo(5, 1) == result_a
+            assert big_foo(5, 2) != result_b
+
             
 
 if __name__ == '__main__':


### PR DESCRIPTION
The change adds support for deleting memoized caches optionally based on function parameters
The change is related to ticket #5
