### PR TITLE
for the case of non-ascii request.path

### DIFF
--- a/flaskext/cache/__init__.py
+++ b/flaskext/cache/__init__.py
@@ -139,6 +139,7 @@ class Cache(object):
                     cache_key = key_prefix % request.path
                 else:
                     cache_key = key_prefix
+                cache_key = cache_key.encode('utf-8')
                 
                 rv = self.cache.get(cache_key)
                 if rv is None:


### PR DESCRIPTION
Hello

When I use cached() for a view function with URL encoded non-ascii character in request.path, werkzeug raised an exception.
Since Flask provides request.path as unicode object, it is better to decode it to utf-8 or something.

P.S.
Another direction might be passing callable to key_prefix argument so that users can change prefix key more flexibly.
