### PR TITLE
Add RedisCache

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,6 +42,7 @@ The following configuration values exist for Flask-Cache:
                                 * **simple**: SimpleCache
                                 * **memcached**: MemcachedCache
                                 * **gaememcached**: GAEMemcachedCache
+                                * **redis**: RedisCache (Werkzeug 0.7 required)
                                 * **filesystem**: FileSystemCache
                                 
 ``CACHE_ARGS``                  Optional list to unpack and pass during
@@ -62,6 +63,9 @@ The following configuration values exist for Flask-Cache:
                                 GAEMemcachedCache.
 ``CACHE_MEMCACHED_SERVERS``     A list or a tuple of server addresses.
                                 Used only for MemcachedCache
+``CACHE_REDIS_HOST``            A Redis server host. Used only for RedisCache.
+``CACHE_REDIS_PORT``            A Redis server port. Default is 6379.
+                                Used only for RedisCache.
 ``CACHE_DIR``                   Directory to store cache. Used only for
                                 FileSystemCache.
 =============================== =========================================

--- a/flaskext/cache/backends.py
+++ b/flaskext/cache/backends.py
@@ -16,8 +16,20 @@ def memcached(app, args, kwargs):
 def gaememcached(app, args, kwargs):
     kwargs.update(dict(key_prefix=app.config['CACHE_KEY_PREFIX']))
     return GAEMemcachedCache(*args, **kwargs)
-    
+
 def filesystem(app, args, kwargs):
     args.append(app.config['CACHE_DIR'])
     kwargs.update(dict(threshold=app.config['CACHE_THRESHOLD']))
     return FileSystemCache(*args, **kwargs)
+
+# RedisCache is supported since Werkzeug 0.7.
+try:
+    from werkzeug.contrib.cache import RedisCache
+except ImportError:
+    pass
+else:
+    def redis(app, args, kwargs):
+        kwargs.update(dict(host=app.config['CACHE_REDIS_HOST'],
+                           port=app.config.get('CACHE_REDIS_PORT', 6379)))
+        return RedisCache(*args, **kwargs)
+    


### PR DESCRIPTION
Werkzeug 0.7 has started support Redis cache. http://werkzeug.pocoo.org/docs/contrib/cache/#werkzeug.contrib.cache.RedisCache
