### PR TITLE
abstracting cache_key, cache_timeout, and original function out of decorated function

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,1 @@
+David Baumgold <david@davidbaumgold.com>

--- a/test_cache.py
+++ b/test_cache.py
@@ -48,56 +48,57 @@ class CacheTestCase(unittest.TestCase):
         assert self.cache.get('hi') is None
         
     def test_03_cached_view(self):
-        
-        @self.app.route('/')
-        @self.cache.cached(5)
-        def cached_view():
-            return str(time.time())
-        
-        tc = self.app.test_client()
-        
-        rv = tc.get('/')
-        the_time = rv.data
-        
-        time.sleep(2)
-        
-        rv = tc.get('/')
-        
-        assert the_time == rv.data
-        
-        time.sleep(5)
-        
-        rv = tc.get('/')
-        assert the_time != rv.data
+        with self.app.test_request_context():
+            @self.app.route('/')
+            @self.cache.cached(5)
+            def cached_view():
+                return str(time.time())
+            
+            tc = self.app.test_client()
+            
+            rv = tc.get('/')
+            the_time = rv.data
+            
+            time.sleep(2)
+            
+            rv = tc.get('/')
+            
+            assert the_time == rv.data
+            
+            time.sleep(5)
+            
+            rv = tc.get('/')
+            assert the_time != rv.data
         
     def test_04_cached_view_unless(self):        
-        @self.app.route('/a')
-        @self.cache.cached(5, unless=lambda: True)
-        def non_cached_view():
-            return str(time.time())
-        
-        @self.app.route('/b')
-        @self.cache.cached(5, unless=lambda: False)
-        def cached_view():
-            return str(time.time())
-                
-        tc = self.app.test_client()
-        
-        rv = tc.get('/a')
-        the_time = rv.data
-        
-        time.sleep(1)
-        
-        rv = tc.get('/a')
-        assert the_time != rv.data
-        
-        rv = tc.get('/b')
-        the_time = rv.data
-        
-        time.sleep(1)
-        rv = tc.get('/b')
-        
-        assert the_time == rv.data
+        with self.app.test_request_context():
+            @self.app.route('/a')
+            @self.cache.cached(5, unless=lambda: True)
+            def non_cached_view():
+                return str(time.time())
+            
+            @self.app.route('/b')
+            @self.cache.cached(5, unless=lambda: False)
+            def cached_view():
+                return str(time.time())
+                    
+            tc = self.app.test_client()
+            
+            rv = tc.get('/a')
+            the_time = rv.data
+            
+            time.sleep(1)
+            
+            rv = tc.get('/a')
+            assert the_time != rv.data
+            
+            rv = tc.get('/b')
+            the_time = rv.data
+            
+            time.sleep(1)
+            rv = tc.get('/b')
+            
+            assert the_time == rv.data
         
     def test_05_cached_function(self):
         

--- a/test_cache.py
+++ b/test_cache.py
@@ -216,9 +216,93 @@ class CacheTestCase(unittest.TestCase):
             
             assert big_foo(1, dict(one=1,two=2)) != result_a
             assert big_foo(5, dict(three=3,four=4)) == result_b
+
+    def test_11_cache_key_property(self):
+        with self.app.test_request_context():
+            @self.app.route('/')
+            @self.cache.cached(5)
+            def cached_view():
+                return str(time.time())
+
+            assert hasattr(cached_view, "cache_key")
+            assert isinstance(cached_view.cache_key, basestring)
+
+            tc = self.app.test_client()
             
-                    
+            rv = tc.get('/')
+            the_time = rv.data
+
+            cache_data = self.cache.get(cached_view.cache_key)
+            assert the_time == cache_data
+
+    def test_12_make_cache_key_function_property(self):
+        with self.app.test_request_context():
+            @self.app.route('/<foo>/<bar>')
+            @self.cache.memoize(5)
+            def cached_view(foo, bar):
+                return str(time.time())
+
+            assert hasattr(cached_view, "make_cache_key")
+            assert callable(cached_view.make_cache_key)
+
+            tc = self.app.test_client()
             
+            rv = tc.get('/a/b')
+            the_time = rv.data
+
+            cache_key = cached_view.make_cache_key(foo=u"a", bar=u"b")
+            cache_data = self.cache.get(cache_key)
+            assert the_time == cache_data
+
+            different_key = cached_view.make_cache_key(foo=u"b", bar=u"a")
+            different_data = self.cache.get(different_key)
+            assert the_time != different_data
+
+    def test_13_cache_timeout_property(self):
+        with self.app.test_request_context():
+            @self.app.route('/')
+            @self.cache.memoize(5)
+            def cached_view1():
+                return str(time.time())
+
+            @self.app.route('/<foo>/<bar>')
+            @self.cache.memoize(10)
+            def cached_view2(foo, bar):
+                return str(time.time())
+
+            assert hasattr(cached_view1, "cache_timeout")
+            assert hasattr(cached_view2, "cache_timeout")
+            assert cached_view1.cache_timeout == 5
+            assert cached_view2.cache_timeout == 10
+
+            # test that this is a read-write property
+            cached_view1.cache_timeout = 2
+            cached_view2.cache_timeout = 3
+
+            assert cached_view1.cache_timeout == 2
+            assert cached_view2.cache_timeout == 3
+
+            tc = self.app.test_client()
+
+            rv1 = tc.get('/')
+            time1 = rv1.data
+            time.sleep(1)
+            rv2 = tc.get('/a/b')
+            time2 = rv2.data
+
+            # VIEW1
+            # it's been 1 second, cache is still active
+            assert time1 == tc.get('/').data
+            time.sleep(2)
+            # it's been 3 seconds, cache is not still active
+            assert time1 != tc.get('/').data
+
+            # VIEW2
+            # it's been 2 seconds, cache is still active
+            assert time2 == tc.get('/a/b').data
+            time.sleep(2)
+            # it's been 4 seconds, cache is not still active
+            assert time2 != tc.get('/a/b').data
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This branch makes the internals of Flask-Cache more accessible to developers. The
function returned by the cached() decorator has three attributes on it: `cache_key`,
a string containing the key used to cache the results of the function;
`cache_timeout`, the same value passed to the decorator, and `uncached`, the original
function that was decorated. These attributes are both readable and writable, and
the decorated function will pick up changes to these attributes. This allows
developers to access and modify the cache entry for a function (useful for prewarming
caches, for example), access and modify cache timeouts (adjusting caches on the fly),
and an easy way to manually call the original function without caching.

The memoized() decorator has the same attributes, but instead of a `cache_key` string
attribute, it has a `make_cache_key` function, which accepts the same arguments
that the underlying function does.

I've added some unit tests, but I haven't updated the documentation -- I'm not familiar with the documentation style, so I was hoping that you could give me some suggestions, or update it yourself. This change will definitely require a bump in the minor version, as per [semantic versioning](http://www.semver.org).
