### PR TITLE
Fix make_cache_key to work with functions

### DIFF
--- a/flaskext/cache/__init__.py
+++ b/flaskext/cache/__init__.py
@@ -179,10 +179,10 @@ class Cache(object):
                 return rv
 
             def make_cache_key(*args, **kwargs):
-                if '%s' in key_prefix:
-                    cache_key = key_prefix % request.path
-                elif callable(key_prefix):
+                if callable(key_prefix):
                     cache_key = key_prefix()
+                elif '%s' in key_prefix:
+                    cache_key = key_prefix % request.path
                 else:
                     cache_key = key_prefix
 


### PR DESCRIPTION
[The function make_cache_key](https://github.com/thadeusb/flask-cache/blob/master/flaskext/cache/__init__.py#L181) first checks if '%s' is in key_prefix, then checks if key_prefix is callable. This causes a TypeError when passing a function, because functions cannot be iterated over. The possible workaround is to pass an instance of a class that is both iterable and callable as the key_prefix, although the obvious fix is to check if key_prefix is callable first.
