### PR TITLE
add pylibmc to python requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     install_requires=[
         'setuptools',
         'Flask',
+        'pylibmc',
     ],
     test_suite='test_cache',
     classifiers=[


### PR DESCRIPTION
Flask-Cache won't work with memcached unless pylibmc is installed. This should be listed in setup.py as a dependency or at the very least added as note in the docs under the CACHE_TYPE config option.
