### PR TITLE
Remove setuptools from install requirements in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup
 
 setup(
     name='Flask-Cache',
-    version='0.7.1',
+    version='0.7.2-dev',
     url='http://github.com/thadeusb/flask-cache',
     license='BSD',
     author='Thadeus Burgess',
@@ -26,8 +26,7 @@ setup(
     zip_safe=False,
     platforms='any',
     install_requires=[
-        'setuptools',
-        'Flask',
+        'Flask'
     ],
     test_suite='test_cache',
     classifiers=[


### PR DESCRIPTION
Remove setuptools from install requirements in setup.py. Its not necessary and causes failures with pip when installing a bundled environment.
