### PR TITLE
handling exceptions when getting keys from internal cache object

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -164,7 +164,7 @@ example, lets say you change the users permissions and assign them to a role,
 but now you need to re-calculate if they have certain memberships or not.
 You can do this with the :meth:`~Cache.delete_memoized` function.::
 
-	cache.delete_memoized('has_membership')
+	cache.delete_memoized('user_has_membership')
 
 .. note::
 
@@ -178,7 +178,7 @@ You can do this with the :meth:`~Cache.delete_memoized` function.::
      user_has_membership('demo', 'admin')
      user_has_membership('demo', 'user')
 
-     cache.delete_memoized('has_membership', 'demo', 'user')
+     cache.delete_memoized('user_has_membership', 'demo', 'user')
 
 
 Custom Cache Backends

--- a/flask_cache/__init__.py
+++ b/flask_cache/__init__.py
@@ -110,7 +110,10 @@ class Cache(object):
 
     def get(self, *args, **kwargs):
         "Proxy function for internal cache object."
-        return self.cache.get(*args, **kwargs)
+        try:
+            return self.cache.get(*args, **kwargs)
+        except exceptions.Exception:
+            return None
 
     def set(self, *args, **kwargs):
         "Proxy function for internal cache object."
@@ -191,7 +194,7 @@ class Cache(object):
 
                 cache_key = decorated_function.make_cache_key(*args, **kwargs)
 
-                rv = self.cache.get(cache_key)
+                rv = self.get(cache_key)
                 if rv is None:
                     rv = f(*args, **kwargs)
                     self.cache.set(cache_key, rv,
@@ -229,7 +232,7 @@ class Cache(object):
         """
         def make_cache_key(f, *args, **kwargs):
             version_key = self._memvname(fname)
-            version_data = self.cache.get(version_key)
+            version_data = self.get(version_key)
 
             if version_data is None:
                 version_data = self.memoize_make_version_hash()
@@ -345,7 +348,7 @@ class Cache(object):
 
                 cache_key = decorated_function.make_cache_key(f, *args, **kwargs)
 
-                rv = self.cache.get(cache_key)
+                rv = self.get(cache_key)
                 if rv is None:
                     rv = f(*args, **kwargs)
                     self.cache.set(cache_key, rv,

--- a/flask_cache/__init__.py
+++ b/flask_cache/__init__.py
@@ -110,10 +110,7 @@ class Cache(object):
 
     def get(self, *args, **kwargs):
         "Proxy function for internal cache object."
-        try:
-            return self.cache.get(*args, **kwargs)
-        except exceptions.Exception:
-            return None
+        return self.cache.get(*args, **kwargs)
 
     def set(self, *args, **kwargs):
         "Proxy function for internal cache object."


### PR DESCRIPTION
When using cache type memcached, the cache interface can raise an exception when getting keys.

For example:

When using pylibmc if the memcached server restarts, the cache interface will raise a _pylibmc.UnknownReadFailure exception. This propagates back up to Flask and causes the request to fail, seen below.

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1701, in __call__
    return self.wsgi_app(environ, start_response)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1689, in wsgi_app
    response = self.make_response(self.handle_exception(e))
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1687, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1360, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1358, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1344, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/local/lib/python2.7/dist-packages/flaskext/cache/__init__.py", line 195, in decorated_function
    rv = self.cache.get(cache_key)
  File "/usr/local/lib/python2.7/dist-packages/werkzeug/contrib/cache.py", line 325, in get
    return self._client.get(key)
_pylibmc.UnknownReadFailure: error 7 from memcached_get(htview//): UNKNOWN READ FAILURE
```
