### PR TITLE
fix bugs in memorize_kwargs_toargs

### DIFF
--- a/flask_cache/__init__.py
+++ b/flask_cache/__init__.py
@@ -281,6 +281,7 @@ class Cache(object):
         arg_num = 0
         argspec = inspect.getargspec(f)
 
+        args_len = len(argspec.args)
         for i in range(len(argspec.args)):
             if i == 0 and argspec.args[i] in ('self', 'cls'):
                 #: use the id of the class instance
@@ -294,7 +295,7 @@ class Cache(object):
                 arg = args[arg_num]
                 arg_num += 1
             else:
-                arg = argspec.defaults[-i]
+                arg = argspec.defaults[i-args_len]
                 arg_num += 1
 
             #: Attempt to convert all arguments to a

--- a/test_cache.py
+++ b/test_cache.py
@@ -233,11 +233,10 @@ class CacheTestCase(unittest.TestCase):
 
     def test_10a_arg_kwarg_memoize(self):
         @self.cache.memoize()
-        def f(a, b=0):
-            pass
+        def f(a, b, c=1):
+            return a+b+c+random.randrange(0, 100000)
 
-        f(1)
-        f(1)
+        assert f(1,2) == f(1,2,1)
 
     def test_10b_classarg_memoize(self):
 


### PR DESCRIPTION
I found that when memoize work on a method with some default args, it's failed. I fixed that.
