### PR TITLE
Fail gracefully when cache backend is not available

### DIFF
--- a/flask_cache/__init__.py
+++ b/flask_cache/__init__.py
@@ -214,6 +214,8 @@ class Cache(object):
                                    timeout=decorated_function.cache_timeout)
                     return rv
                 except Exception as e:
+                    if current_app.debug:
+                        raise e
                     logger.exception("Exception possibly due to cache backend.")
                     return f(*args, **kwargs)
 
@@ -401,6 +403,8 @@ class Cache(object):
                                    timeout=decorated_function.cache_timeout)
                     return rv
                 except Exception as e:
+                    if current_app.debug:
+                        raise e
                     logger.exception("Exception possibly due to cache backend.")
                     return f(*args, **kwargs)
 


### PR DESCRIPTION
When the cache backend is not available, the application should not fail because of the backend not being available.

Tools like [1] help testing this kind of behaviour.

[1] http://vaurien.readthedocs.org/en/1.5/
