### PR TITLE
Support for db number in redis cache with db defaulted to 0

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -228,6 +228,8 @@ The following configuration values exist for Flask-Cache:
 ``CACHE_REDIS_PORT``            A Redis server port. Default is 6379.
                                 Used only for RedisCache.
 ``CACHE_REDIS_PASSWORD``        A Redis password for server. Used only for RedisCache.
+``CACHE_REDIS_DB``              A Redis db (zero-based number index). Default is 0.
+                                Used only for RedisCache.
 ``CACHE_DIR``                   Directory to store cache. Used only for
                                 FileSystemCache.
 =============================== ==================================================================
@@ -318,6 +320,7 @@ RedisCache -- redis
 - CACHE_REDIS_HOST
 - CACHE_REDIS_PORT
 - CACHE_REDIS_PASSWORD
+- CACHE_REDIS_DB
 - CACHE_ARGS
 - CACHE_OPTIONS
 

--- a/flask_cache/backends.py
+++ b/flask_cache/backends.py
@@ -66,4 +66,7 @@ else:
         if key_prefix:
             kwargs['key_prefix'] = key_prefix
 
+        db_number = config.get('CACHE_REDIS_DB')
+        if db_number:
+            kwargs['db'] = db_number
         return RedisCache(*args, **kwargs)


### PR DESCRIPTION
Redis allows multiple dbs with zero based numeric index. Added a option to select db on which to connect.

Dependent on pull request on werkzeug https://github.com/mitsuhiko/werkzeug/pull/257 
