### PR TITLE
when using init_app still set self.app

### DIFF
--- a/flask_cache/__init__.py
+++ b/flask_cache/__init__.py
@@ -67,6 +67,8 @@ class Cache(object):
 
     def init_app(self, app, config=None):
         "This is used to initialize cache with your app object"
+        self.app = app
+
         if not isinstance(config, (NoneType, dict)):
             raise ValueError("`config` must be an instance of dict or NoneType")
 


### PR DESCRIPTION
I noticed that when using init_app the `self.app` was no longer being set.

You don't seem to use it except to access `app.extensions['cache']` but some people (like me) might overload your class and then it's nice to have `self.app` available.

If you disagree I guess you should remove `self.app` completely since imo the Cache(app) behavory should be exactly the same as when using init_app. 
