### PR TITLE
cache more set/get exception in backend

### DIFF
--- a/flask_cache/__init__.py
+++ b/flask_cache/__init__.py
@@ -215,9 +215,8 @@ class Cache(object):
                 if callable(unless) and unless() is True:
                     return f(*args, **kwargs)
 
-                cache_key = decorated_function.make_cache_key(*args, **kwargs)
-
                 try:
+                    cache_key = decorated_function.make_cache_key(*args, **kwargs)
                     rv = self.cache.get(cache_key)
                 except Exception as e:
                     if current_app.debug:
@@ -419,9 +418,8 @@ class Cache(object):
                 if callable(unless) and unless() is True:
                     return f(*args, **kwargs)
 
-                cache_key = decorated_function.make_cache_key(f, *args, **kwargs)
-
                 try:
+                    cache_key = decorated_function.make_cache_key(f, *args, **kwargs)
                     rv = self.cache.get(cache_key)
                 except Exception as e:
                     if current_app.debug:
@@ -523,10 +521,15 @@ class Cache(object):
 
         _fname = function_namespace(f, args)
 
-        if not args and not kwargs:
-            version_key = self._memvname(_fname)
-            version_data = self.memoize_make_version_hash()
-            self.cache.set(version_key, version_data)
-        else:
-            cache_key = f.make_cache_key(f.uncached, *args, **kwargs)
-            self.cache.delete(cache_key)
+        try:
+            if not args and not kwargs:
+                version_key = self._memvname(_fname)
+                version_data = self.memoize_make_version_hash()
+                self.cache.set(version_key, version_data)
+            else:
+                cache_key = f.make_cache_key(f.uncached, *args, **kwargs)
+                self.cache.delete(cache_key)
+        except Exception as e:
+            if current_app.debug:
+                raise e
+            logger.exception("Exception possibly due to cache backend.")


### PR DESCRIPTION
See #57 :

> I saw that you catched get/set error [here](https://github.com/thadeusb/flask-cache/blob/master/flask_cache/__init__.py#L221) and [here](https://github.com/thadeusb/flask-cache/blob/master/flask_cache/__init__.py#L425) , but if set/get fail there is a big chance that `cache_key = decorated_function.make_cache_key(*args, **kwargs)` fails 3 line above in each case and also [here](https://github.com/thadeusb/flask-cache/blob/master/flask_cache/__init__.py#L531) .
> 
> should I move it inside the try/catch too ? and wrap in a try catch for the 3rd case ?
