### PR TITLE
Actually use repr instead of id

### DIFF
--- a/flask_cache/__init__.py
+++ b/flask_cache/__init__.py
@@ -316,10 +316,11 @@ class Cache(object):
         args_len = len(argspec.args)
         for i in range(args_len):
             if i == 0 and argspec.args[i] in ('self', 'cls'):
-                #: use the id of the class instance
+                #: use the repr of the class instance
                 #: this supports instance methods for
-                #: the memoized functions.
-                arg = id(args[0])
+                #: the memoized functions, giving more
+                #: flexibility to developers
+                arg = repr(args[0])
                 arg_num += 1
             elif argspec.args[i] in kwargs:
                 arg = kwargs[argspec.args[i]]


### PR DESCRIPTION
When memoizing an instance method, the documentation mentions the `sqlalchemy` example and says the cache key is created using `repr(self)`. Yet the code does use `id`. This PR fixes it.

The code does mention the possibility of having a `__cacherepr__` method, this sounds even better because then it's explicit.
