### PR TITLE
Clear cache

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -216,7 +216,7 @@ The following configuration values exist for Flask-Cache:
 ``CACHE_KEY_PREFIX``            A prefix that is added before all keys.
                                 This makes it possible to use the same
                                 memcached server for different apps.
-                                Used only for MemcachedCache and
+                                Used only for RedisCache, MemcachedCache and
                                 GAEMemcachedCache.
 ``CACHE_MEMCACHED_SERVERS``     A list or a tuple of server addresses.
                                 Used only for MemcachedCache

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -170,6 +170,39 @@ Example::
     </div>
     {% endcache %}
 
+Clearing Cache
+--------------
+
+See :meth:`~Cache.clear`.
+
+Here's an example script to empty your application's cache:
+
+.. code-block:: python
+
+    from flask.ext.cache import Cache
+
+    from yourapp import app, your_cache_config
+
+    cache = Cache()
+
+
+    def main():
+        cache.init_app(app, config=your_cache_config)
+
+        with app.app_context():
+            cache.clear()
+
+    if __name__ == '__main__':
+        main()
+
+
+.. warning::
+
+    Some backend implementation do not support completely clearing the case.
+    Also, if you're not using key prefix, some implementation (e.g. Redis)
+    will flush the whole database. Make sure you're not storing any other
+    data in your caching database.
+
 Configuring Flask-Cache
 -----------------------
 
@@ -384,7 +417,7 @@ API
 
 .. autoclass:: Cache
    :members: init_app,
-             get, set, add, delete, get_many, set_many, delete_many,
+             get, set, add, delete, get_many, set_many, delete_many, clear,
              cached, memoize, delete_memoized, delete_memoized_verhash
 
 .. include:: ../CHANGES

--- a/flask_cache/__init__.py
+++ b/flask_cache/__init__.py
@@ -147,6 +147,10 @@ class Cache(object):
         "Proxy function for internal cache object."
         self.cache.delete_many(*args, **kwargs)
 
+    def clear(self):
+        "Proxy function for internal cache object."
+        self.cache.clear()
+
     def get_many(self, *args, **kwargs):
         "Proxy function for internal cache object."
         return self.cache.get_many(*args, **kwargs)

--- a/flask_cache/__init__.py
+++ b/flask_cache/__init__.py
@@ -77,7 +77,7 @@ class Cache(object):
 
         config.setdefault('CACHE_DEFAULT_TIMEOUT', 300)
         config.setdefault('CACHE_THRESHOLD', 500)
-        config.setdefault('CACHE_KEY_PREFIX', None)
+        config.setdefault('CACHE_KEY_PREFIX', 'flask_cache_')
         config.setdefault('CACHE_MEMCACHED_SERVERS', None)
         config.setdefault('CACHE_DIR', None)
         config.setdefault('CACHE_OPTIONS', None)


### PR DESCRIPTION
This PR adds the ability to clear the cache.

It also adds a default `key_prefix`. Not sure it's a good idea, would love to get your thoughts on that. It's just to prevent a user from inadvertently flushing the whole Redis database.
