### PR TITLE
Add config variable to silent the null warning message

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -202,6 +202,8 @@ The following configuration values exist for Flask-Cache:
                                 * **filesystem**: FileSystemCache
                                 * **saslmemcached**: SASLMemcachedCache (pylibmc required)
 
+``CACHE_NO_NULL_WARNING``       Silents the warning message when using
+                                cache type of 'null'.
 ``CACHE_ARGS``                  Optional list to unpack and pass during
                                 the cache class instantiation.
 ``CACHE_OPTIONS``               Optional dictionary to pass during the

--- a/flask_cache/__init__.py
+++ b/flask_cache/__init__.py
@@ -83,8 +83,9 @@ class Cache(object):
         config.setdefault('CACHE_OPTIONS', None)
         config.setdefault('CACHE_ARGS', [])
         config.setdefault('CACHE_TYPE', 'null')
+        config.setdefault('CACHE_NO_NULL_WARNING', False)
 
-        if config['CACHE_TYPE'] == 'null':
+        if config['CACHE_TYPE'] == 'null' and not config['CACHE_NO_NULL_WARNING']:
             warnings.warn("Flask-Cache: CACHE_TYPE is set to null, "
                           "caching is effectively disabled.")
 


### PR DESCRIPTION
Config variable is 'CACHE_NO_NULL_WARNING' to indicate using 'null' is intentional. This is useful for development environments when caching gets in the way and `null` is deliberate.
