### PR TITLE
Fix issue with Jinja2 cache-tag not deleting and change template tag to use stable keys

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include LICENSE CHANGES *.py
+include test_template.html
 recursive-include docs *
 recursive-exclude docs *.pyc
 recursive-exclude docs *.pyo

--- a/flask_cache/__init__.py
+++ b/flask_cache/__init__.py
@@ -28,6 +28,8 @@ from flask import request, current_app
 
 logger = logging.getLogger(__name__)
 
+TEMPLATE_FRAGMENT_KEY_TEMPLATE = '_template_fragment_cache_%s%s'
+
 
 def function_namespace(f, args=None):
     """
@@ -47,6 +49,15 @@ def function_namespace(f, args=None):
         return '%s.%s.%s' % (f.__module__, f.__class__.__name__, f.__name__)
     else:
         return '%s.%s' % (f.__module__, f.__name__)
+
+
+def make_template_fragment_key(fragment_name, vary_on=[]):
+    """
+    Make a cache key for a specific fragment name
+    """
+    if vary_on:
+        fragment_name = "%s_" % fragment_name
+    return TEMPLATE_FRAGMENT_KEY_TEMPLATE % (fragment_name, "_".join(vary_on))
 
 
 #: Cache Object

--- a/flask_cache/jinja2ext.py
+++ b/flask_cache/jinja2ext.py
@@ -67,11 +67,12 @@ class CacheExtension(Extension):
         except AttributeError, e:
             raise e
 
+        key = '_'.join(keys_list)
+
         if timeout == "del":
-            cache.delete_many(*keys_list)
+            cache.delete(key)
             return caller()
 
-        key = '_'.join(keys_list)
         rv = cache.get(key)
 
         if rv is None:

--- a/test_cache.py
+++ b/test_cache.py
@@ -4,8 +4,9 @@ import sys
 import os
 import time
 import random
+import string
 
-from flask import Flask
+from flask import Flask, render_template
 from flask.ext.cache import Cache, function_namespace
 
 if sys.version_info < (2,7):
@@ -19,7 +20,7 @@ class CacheTestCase(unittest.TestCase):
         app.config['CACHE_TYPE'] = 'simple'
 
     def setUp(self):
-        app = Flask(__name__)
+        app = Flask(__name__, template_folder=os.path.dirname(__file__))
 
         app.debug = True
         self._set_app_config(app)
@@ -496,6 +497,28 @@ class CacheTestCase(unittest.TestCase):
         cache.init_app(self.app, config={'CACHE_TYPE': 'simple'})
         from werkzeug.contrib.cache import SimpleCache
         assert isinstance(self.app.extensions['cache'][cache], SimpleCache)
+
+    def test_20_jinja2ext_cache(self):
+        somevar = ''.join([random.choice(string.ascii_letters) for x in range(6)])
+        filename = self.app.jinja_env.get_template("test_template.html").filename
+
+        testkeys = [
+            "%s1" % filename,
+            "%s2_key1" % filename,
+            "%s3_key1_%s" % (filename, somevar)
+        ]
+        delkey = "%s4_key2" % filename
+
+        with self.app.test_request_context():
+            render_template("test_template.html", somevar=somevar, timeout=60)
+            for k in testkeys:
+                assert self.cache.get(k) == somevar
+            assert self.cache.get(delkey) == somevar
+            render_template("test_template.html", somevar=somevar, timeout="del")
+            for k in testkeys:
+                assert self.cache.get(k) == somevar
+            assert self.cache.get(delkey) is None
+
 
 if 'TRAVIS' in os.environ:
     try:

--- a/test_template.html
+++ b/test_template.html
@@ -1,4 +1,4 @@
-{% cache 60 %}{{somevar}}{% endcache %}
-{% cache 60, "key1" %}{{somevar}}{% endcache %}
-{% cache 60, "key1", somevar %}{{somevar}}{% endcache %}
-{% cache timeout, "key2" %}{{somevar}}{% endcache %}
+{% cache 60, "fragment1" %}{{somevar}}{% endcache %}
+{% cache 60, "fragment1", "key1" %}{{somevar}}{% endcache %}
+{% cache 60, "fragment1", "key1", somevar %}{{somevar}}{% endcache %}
+{% cache timeout, "fragment2" %}{{somevar}}{% endcache %}

--- a/test_template.html
+++ b/test_template.html
@@ -1,0 +1,4 @@
+{% cache 60 %}{{somevar}}{% endcache %}
+{% cache 60, "key1" %}{{somevar}}{% endcache %}
+{% cache 60, "key1", somevar %}{{somevar}}{% endcache %}
+{% cache timeout, "key2" %}{{somevar}}{% endcache %}


### PR DESCRIPTION
**Fix issue with Jinja2 cache-tag not deleting keys:**
- The `{% cache "del" ... %}` tag does not delete the keys when
  the timeout is set to "del". be4543a fixes this issue,
  and adds a test case.

**Change cache-tag to use stable keys:**
The current cache-template tag generates cache keys based on the template name,
line number and possible additional keys. Especially the lineno make it hard to
have stable and predictable cache keys which can be invalidated from outside
the template when underlying data changes. Also, since the filename was used
the cache-tag was not usable when rendering a template directly from a string.

dc1ca07 changes the template tag to require a fragment name:

```
{% cache timeout, "fragmentname" %}
{% cache timeout, "fragmentname", "vary_on1", ... %}
```

and the cache key can easily be generate via a new method:

```
from flask.ext.cache import make_template_fragment_key
make_template_fragment_key("fragmentname")
cache.delete(key)
```

Backward incompatible changes:
- `{% cache timeout %}` will no long work. Should be replace with `{% cache timeout "fragmentname "%}`
- Possible key collision for old keys if same fragment name is used.
