### PR TITLE
Add simple config to the documentation to make it working right away.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,12 +23,12 @@ Cache is managed through a ``Cache`` instance::
     from flask.ext.cache import Cache
 
     app = Flask(__name__)
-    cache = Cache(app)
+    cache = Cache(app,config={'CACHE_TYPE': 'simple'})
 
 You may also set up your ``Cache`` instance later at configuration time using
 **init_app** method::
 
-    cache = Cache()
+    cache = Cache(config={'CACHE_TYPE': 'simple'})
 
     app = Flask(__name__)
     cache.init_app(app)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,7 @@ Cache is managed through a ``Cache`` instance::
     from flask.ext.cache import Cache
 
     app = Flask(__name__)
+    # Check Configuring Flask-Cache section for more details
     cache = Cache(app,config={'CACHE_TYPE': 'simple'})
 
 You may also set up your ``Cache`` instance later at configuration time using


### PR DESCRIPTION
I have just installed Flask-Cache, and realized after a bit that it's printing "CACHE_TYPE" is set to null. Let's not confuse the users; If I implement the sample at the documentation, it should be working. 
