### PR TITLE
Allow deleting parameterless memoized caches

### DIFF
--- a/flask_cache/__init__.py
+++ b/flask_cache/__init__.py
@@ -276,7 +276,7 @@ class Cache(object):
     def memoize_make_version_hash(self):
         return base64.b64encode(uuid.uuid4().bytes)[:6].decode('utf-8')
 
-    def memoize_make_cache_key(self, make_name=None):
+    def memoize_make_cache_key(self, make_name=None, timeout=None):
         """
         Function used to create the cache_key for memoized functions.
         """
@@ -288,7 +288,7 @@ class Cache(object):
 
             if version_data is None:
                 version_data = self.memoize_make_version_hash()
-                self.cache.set(version_key, version_data)
+                self.cache.set(version_key, version_data, timeout=timeout)
 
             cache_key = hashlib.md5()
 
@@ -458,7 +458,7 @@ class Cache(object):
 
             decorated_function.uncached = f
             decorated_function.cache_timeout = timeout
-            decorated_function.make_cache_key = self.memoize_make_cache_key(make_name)
+            decorated_function.make_cache_key = self.memoize_make_cache_key(make_name, timeout)
             decorated_function.delete_memoized = lambda: self.delete_memoized(f)
 
             return decorated_function
@@ -540,8 +540,7 @@ class Cache(object):
         try:
             if not args and not kwargs:
                 version_key = self._memvname(_fname)
-                version_data = self.memoize_make_version_hash()
-                self.cache.set(version_key, version_data)
+                self.cache.delete(version_key)
             else:
                 cache_key = f.make_cache_key(f.uncached, *args, **kwargs)
                 self.cache.delete(cache_key)


### PR DESCRIPTION
I have some functions that take no parameters that I'm caching using memoize().  They typically expire in 48 hours (fairly static), but if I update something, I want to manually delete and refresh the cache.  Prior to this patch, the following code would cause the cache of myFunc() to ignore the timeout parameter in the memoize() decorator:

``` python
cache.delete_memoized(myFunc)
myFunc()
```

This is because the version_key had no timeout set, so it was expiring in 240 seconds with my Redis backend (perhaps that is the default I had set somewhere).  Regardless, it wasn't using the timeout parameter that the version_data was using thus making the cache effectively expire far before I wanted it to.  Since I don't want to have to pass a timeout parameter into delete_memoized(), I also changed the behaviour to delete the cache regardless of whether there are function parameters or not.
