### PR TITLE
No need to call memoized function again on exception

### DIFF
--- a/flask_cache/__init__.py
+++ b/flask_cache/__init__.py
@@ -453,7 +453,6 @@ class Cache(object):
                         if current_app.debug:
                             raise
                         logger.exception("Exception possibly due to cache backend.")
-                        return f(*args, **kwargs)
                 return rv
 
             decorated_function.uncached = f


### PR DESCRIPTION
`rv` already has original function result and it will be returned after next line execution
