### PR TITLE
adding :is_null to Cache

### DIFF
--- a/flask_cache/__init__.py
+++ b/flask_cache/__init__.py
@@ -22,6 +22,7 @@ import uuid
 import warnings
 
 from werkzeug import import_string
+from werkzeug.contrib.cache import NullCache
 from flask import request, current_app
 
 from ._compat import PY2
@@ -190,6 +191,10 @@ class Cache(object):
     def cache(self):
         app = self.app or current_app
         return app.extensions['cache'][self]
+
+    @property
+    def is_null(self):
+        return not self.cache or isinstance(self.cache, NullCache)
 
     def get(self, *args, **kwargs):
         "Proxy function for internal cache object."


### PR DESCRIPTION
adding :is_null property to so that application code can check if the cache is NullCache without having to know the internal workings of the Cache class.

Also added back the `self.app = app` to keep behavior between `Cache(app)` and `Cache().init_app(app)` the same. atm it's falling back to `current_app`, which is unnecessary. 
