### PR TITLE
adding "CacheContext" functionality to memoize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ docs/_build/*
 Flask_Cache.egg-info/*
 build/*
 dist/
+.settings
+.idea
+.pydevproject
+.project

--- a/flask_cache/__init__.py
+++ b/flask_cache/__init__.py
@@ -490,16 +490,20 @@ class Cache(object):
         scope = self.get_memoize_context_scope()
         scope.memoize_context = ctx
 
-    def new_memoize_context(self, *contextkeys):
+    def new_memoize_context(self, contextkeys=None):
         memoize_context = MemoizeContext(self)
 
         for key in self.default_memoize_context:
             memoize_context.add_key(key)
 
+        return self.add_memoize_contextkeys(contextkeys, memoize_context=memoize_context)
+
+    def add_memoize_contextkeys(self, contextkeys=None, memoize_context=None):
+        memoize_context = memoize_context or self.memoize_context
 
         if contextkeys:
-            if len(contextkeys) == 1 and isinstance(contextkeys[0], (list, tuple)):
-                contextkeys = contextkeys[0]
+            if isinstance(contextkeys, basestring):
+                contextkeys = [contextkeys]
 
             for key in filter(None, contextkeys):
                 memoize_context.add_key(key)
@@ -524,7 +528,7 @@ class Cache(object):
 
             @functools.wraps(fn)
             def _in_memoize_context(*args, **kwargs):
-                with self.new_memoize_context(contextkeys) as memoize_context:
+                with self.add_memoize_contextkeys(contextkeys) as memoize_context:
                     memoize_context.in_memoize_context = True
                     return fn(*args, **kwargs)
 

--- a/flask_cache/__init__.py
+++ b/flask_cache/__init__.py
@@ -699,7 +699,9 @@ class NotInCacheContext(Exception):
         self.key = key
 
     def __str__(self):
-        return "Before you can use the [%s] key you have to add it to the cache context first using the `cache.context` decorator." % self.key
+        return "Before you can use the [%s] cache_context key you have to add it to the cache_context first " \
+               "using the `cache.cache_context.add_key` method " \
+               "or add it to the `cache.memoize_with_context` decorator." % self.key
 
 
 class UnknownCacheContextKey(Exception):
@@ -707,5 +709,6 @@ class UnknownCacheContextKey(Exception):
         self.key = key
 
     def __str__(self):
-        return "The cache context key you tried to add [%s] doesn't exists as a property on the cache_context, please add it." % self.key
+        return "The [%s] cache_context key you tried to add isn't configured as a cache_context key, " \
+               "please add it to `cache.cache_context_config`." % self.key
 

--- a/flask_cache/__init__.py
+++ b/flask_cache/__init__.py
@@ -511,12 +511,9 @@ class Cache(object):
 
             @functools.wraps(fn)
             def _in_cache_context(*args, **kwargs):
-                if contextkeys:
-                    for key in [contextkeys] if isinstance(contextkeys, basestring) else contextkeys:
-                        self.cache_context.add_key(key)
-
-                self.cache_context.in_cache_context = True
-                return fn(*args, **kwargs)
+                with CacheContext(self, *([contextkeys] if isinstance(contextkeys, basestring) else contextkeys)) as context:
+                    context.in_cache_context = True
+                    return fn(*args, **kwargs)
 
             _in_cache_context.allow_cache_context = True
 
@@ -689,6 +686,8 @@ class CacheContext(object):
 
         self.cache.cache_context = self
         self.in_cache_context = True
+
+        return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.cache.cache_context = self.parent

--- a/flask_cache/__init__.py
+++ b/flask_cache/__init__.py
@@ -692,10 +692,8 @@ class MemoizeContext(object):
         return str(self.context)
 
     def __enter__(self):
+        # this could be `self`, but that's okay, eventually we'll __exit__ out if __enter__ was nested
         self.parent = self.cache.memoize_context
-
-        if self.parent == self:
-            raise Exception("Entering current MemoizeContext is not possible.")
 
         self.cache.memoize_context = self
         self.in_memoize_context = True

--- a/flask_cache/__init__.py
+++ b/flask_cache/__init__.py
@@ -528,8 +528,7 @@ class Cache(object):
 
             @functools.wraps(fn)
             def _in_memoize_context(*args, **kwargs):
-                with self.add_memoize_contextkeys(contextkeys) as memoize_context:
-                    memoize_context.in_memoize_context = True
+                with self.new_memoize_context(contextkeys) as memoize_context:
                     return fn(*args, **kwargs)
 
             _in_memoize_context.allow_memoize_context = True

--- a/flask_cache/__init__.py
+++ b/flask_cache/__init__.py
@@ -69,6 +69,7 @@ class Cache(object):
     def __init__(self, app=None, with_jinja2_ext=True, config=None):
         self.with_jinja2_ext = with_jinja2_ext
         self.config = config
+        self.default_cache_context = []
 
         self.app = app
         if app is not None:
@@ -481,8 +482,9 @@ class Cache(object):
 
         if not hasattr(scope, 'cache_context'):
             scope.cache_context = CacheContext(self)
-            scope.cache_context.add_key('is_alt_statics')
-            scope.cache_context.add_key('is_HQ')
+
+            for key in self.default_cache_context:
+                scope.cache_context.add_key(key)
 
         return scope.cache_context
 


### PR DESCRIPTION
I initially had subclassed Cache and added all my logic in way that modified the original code the least (easy to update the original code) so the code can be integrated more and cleaned up (and documented) more if you like the concept, just making the PR like this because if you just don't like the concept then there's no point in me cleaing up the code more.  
So if you like the concept; let me know and I'll work on cleaning it up and fixing some stuff.  

A major annoyance for me when using Flask-Cache is that any variables that might cause variations in the pages I'm caching with `@cache.memoize` need to be in the keyword arguments of the function that has the `@cache.memoize`  
and then passed around to whereever it's actually used.

For example, somewhere in small subtemplate that's included in various pages we have an `is_ipad` check which checks the useragent and displays slightly different for an iPad, now my route endpoint looks like this:

``` python
@app.route('/page')
def page():
    return _page(is_ipad = check_is_ipad())

@cache.memoize()
def _page(is_ipad = False):
    return render_the_page(is_ipad = is_ipad)

def render_the_page(is_ipad = False):
    if is_ipad:
        return 'ipad version of page'
    else:
        return 'normal version of page'
```

now with a short code path it's okay, but in our real projects this is_ipad (and a few other vars) were being passed around almost everywhere ...

so I added a 'MemoizeContext', a registery of a few variables that should be added to the cache_key when necessary. 

``` python
app.cache.memoize_context_config['is_ipad'] = check_is_ipad

@app.route('/page')
@cache.memoize_with_context('is_ipad')
def page():
    return render_the_page()

def render_the_page():
    if cache.memoize_context.is_ipad:
        return 'ipad version of page'
    else:
        return 'normal version of page'
```
