### PR TITLE
Pass the memoize parameters into unless().

### DIFF
--- a/test_cache.py
+++ b/test_cache.py
@@ -672,7 +672,7 @@ if 'TRAVIS' in os.environ:
         def test_22_redis_url_explicit_db_arg(self):
             config = {
                 'CACHE_TYPE': 'redis',
-                'CACHE_REDIS_URL': 'redis://localhost:6379/2',
+                'CACHE_REDIS_URL': 'redis://localhost:6379',
                 'CACHE_REDIS_DB': 1,
             }
             cache = Cache()


### PR DESCRIPTION
An attempt to resolve #94 

The expected signature for unless is now:

```
def unless(f, *args, **kwargs):
    pass
```

Also fixes a redis unit test that was breaking because of the URL (this already breaking as soon as I forked from master with no changes).
