### PR TITLE
Moves setting the app attribute to the _set_cache method

### DIFF
--- a/flask_cache/__init__.py
+++ b/flask_cache/__init__.py
@@ -116,7 +116,6 @@ class Cache(object):
         self.with_jinja2_ext = with_jinja2_ext
         self.config = config
 
-        self.app = app
         if app is not None:
             self.init_app(app, config)
 
@@ -185,6 +184,7 @@ class Cache(object):
         app.extensions.setdefault('cache', {})
         app.extensions['cache'][self] = cache_obj(
                 app, config, cache_args, cache_options)
+        self.app = app
 
     @property
     def cache(self):

--- a/test_cache.py
+++ b/test_cache.py
@@ -619,6 +619,11 @@ class CacheTestCase(unittest.TestCase):
             assert self.cache.get(k) == somevar
             assert output == somevar
 
+    def test_21_init_app_sets_app_attribute(self):
+        cache = Cache()
+        cache.init_app(self.app)
+        assert cache.app == self.app
+
 
 if 'TRAVIS' in os.environ:
     try:


### PR DESCRIPTION
Initializing a Cache instance with a None app and setting it later
via init_app causes the app attribute never to be set. This is fine for
most cases, since the cache is being set to the app extension. However,
it causes crashes when calling the Cache outside of a Flask context
(e.g.: spawned threads).

I found this while updating a project I was working on from an old Flask-Cache version to the most up-to-date. Our app was crashing when it spawned gevent threads in order to load data in parallel.
