### PR TITLE
flask.ext.cache is depreciated

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 Flask-Cache
 ================
 
-.. module:: flask.ext.cache
+.. module:: flask_cache
 
 Installation
 ------------
@@ -20,7 +20,7 @@ Set Up
 Cache is managed through a ``Cache`` instance::
 
     from flask import Flask
-    from flask.ext.cache import Cache
+    from flask_cache import Cache
 
     app = Flask(__name__)
     # Check Configuring Flask-Cache section for more details
@@ -167,7 +167,7 @@ Set timeout to "del" to delete cached value::
 If keys are provided, you may easily generate the template fragment key and
 delete it from outside of the template context::
 
-    from flask.ext.cache import make_template_fragment_key
+    from flask_cache import make_template_fragment_key
     key = make_template_fragment_key("key1", vary_on=["key2", "key3"])
     cache.delete(key)
 
@@ -192,7 +192,7 @@ Here's an example script to empty your application's cache:
 
 .. code-block:: python
 
-    from flask.ext.cache import Cache
+    from flask_cache import Cache
 
     from yourapp import app, your_cache_config
 

--- a/examples/hello.py
+++ b/examples/hello.py
@@ -2,14 +2,14 @@ import random
 from datetime import datetime
 
 from flask import Flask, jsonify
-from flask.ext.cache import Cache
+from flask_cache import Cache
 
 
 app = Flask(__name__)
 app.config.from_pyfile('hello.cfg')
 cache = Cache(app)
 
-#: This is an example of a cached view 
+#: This is an example of a cached view
 @app.route('/api/now')
 @cache.cached(50)
 def current_time():

--- a/flask_cache/__init__.py
+++ b/flask_cache/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
-    flask.ext.cache
-    ~~~~~~~~~~~~~~
+    flask_cache
+    ~~~~~~~~~~~
 
     Adds cache support to your application.
 

--- a/flask_cache/jinja2ext.py
+++ b/flask_cache/jinja2ext.py
@@ -30,7 +30,7 @@ Example:
 
 from jinja2 import nodes
 from jinja2.ext import Extension
-from flask.ext.cache import make_template_fragment_key
+from flask_cache import make_template_fragment_key
 
 JINJA_CACHE_ATTR_NAME = '_template_fragment_cache'
 

--- a/test_cache.py
+++ b/test_cache.py
@@ -7,7 +7,7 @@ import random
 import string
 
 from flask import Flask, render_template, render_template_string
-from flask.ext.cache import Cache, function_namespace, make_template_fragment_key
+from flask_cache import Cache, function_namespace, make_template_fragment_key
 
 if sys.version_info < (2,7):
     import unittest2 as unittest


### PR DESCRIPTION
As of v0.11 Flask has depreciated usage of `flask.ext.foo` namespace:

[Flask v0.11 Changes](https://github.com/pallets/flask/blob/0e06302c79c50a4b2dd43b2bcd6f909f8994ce5e/CHANGES#L76)
