### PR TITLE
Updates deprecated import format for Flask extensions

### DIFF
--- a/flask_cache/jinja2ext.py
+++ b/flask_cache/jinja2ext.py
@@ -30,7 +30,7 @@ Example:
 
 from jinja2 import nodes
 from jinja2.ext import Extension
-from flask.ext.cache import make_template_fragment_key
+from flask_cache import make_template_fragment_key
 
 JINJA_CACHE_ATTR_NAME = '_template_fragment_cache'
 


### PR DESCRIPTION
Flask 0.11 started to print out warnings about deprecated format of importing modules: "ExtDeprecationWarning: Importing flask.ext.cache is deprecated, use flask_cache instead."
