### PR TITLE
Retain timeout value while reseting version data

### DIFF
--- a/flask_cache/__init__.py
+++ b/flask_cache/__init__.py
@@ -661,7 +661,8 @@ class Cache(object):
 
         try:
             if not args and not kwargs:
-                self._memoize_version(f, reset=True)
+                _timeout = getattr(f, 'cache_timeout', None)
+                self._memoize_version(f, reset=True, timeout=_timeout)
             else:
                 cache_key = f.make_cache_key(f.uncached, *args, **kwargs)
                 self.cache.delete(cache_key)


### PR DESCRIPTION
Timeout is ignored during cache.delete_memoized without providing parameters.
