### PR TITLE
fix ExtDeprecationWarning

### DIFF
--- a/flask_cache/jinja2ext.py
+++ b/flask_cache/jinja2ext.py
@@ -30,7 +30,7 @@ Example:
 
 from jinja2 import nodes
 from jinja2.ext import Extension
-from flask.ext.cache import make_template_fragment_key
+from flask_cache import make_template_fragment_key
 
 JINJA_CACHE_ATTR_NAME = '_template_fragment_cache'
 


### PR DESCRIPTION
In flask 0.11.1 you will receive `ExtDeprecationWarning` if you import flask extension in `flask.ext.extension` format
