### PR TITLE
Add option to fail silently, even when the Flask app is in debug mode.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ python:
  - "2.7"
  - "3.3"
 install:
- - pip install . --use-mirrors
- - pip install coverage --use-mirrors
- - pip install redis --use-mirrors
- - "if [[ $TRAVIS_PYTHON_VERSION == 2.7* ]]; then pip install pylibmc --use-mirrors; fi"
- - "if [[ $TRAVIS_PYTHON_VERSION == 3.3* ]]; then pip install python3-memcached --use-mirrors; fi"
+ - pip install .
+ - pip install coverage
+ - pip install redis
+ - "if [[ $TRAVIS_PYTHON_VERSION == 2.7* ]]; then pip install pylibmc; fi"
+ - "if [[ $TRAVIS_PYTHON_VERSION == 3.3* ]]; then pip install python3-memcached; fi"
 script: nosetests --with-coverage --cover-package=flask_cache
 services:
  - memcached

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -283,6 +283,9 @@ The following configuration values exist for Flask-Cache:
 ``CACHE_REDIS_URL``             URL to connect to Redis server.
                                 Example ``redis://user:password@localhost:6379/2``.
                                 Used only for RedisCache.
+``CACHE_IGNORE_BACKEND_ERRORS`` Silently ignore backend exceptions, logging them instead.
+                                Defaults to ``False`` when the Flask app is in debug mode,
+                                and to ``True`` otherwise.
 =============================== ==================================================================
 
 

--- a/flask_cache/__init__.py
+++ b/flask_cache/__init__.py
@@ -147,6 +147,9 @@ class Cache(object):
         config.setdefault('CACHE_ARGS', [])
         config.setdefault('CACHE_TYPE', 'null')
         config.setdefault('CACHE_NO_NULL_WARNING', False)
+        config.setdefault('CACHE_IGNORE_BACKEND_ERRORS', not app.debug)
+
+        self._ignore_backends_errors = config['CACHE_IGNORE_BACKEND_ERRORS']
 
         if config['CACHE_TYPE'] == 'null' and not config['CACHE_NO_NULL_WARNING']:
             warnings.warn("Flask-Cache: CACHE_TYPE is set to null, "
@@ -288,7 +291,7 @@ class Cache(object):
                     cache_key = decorated_function.make_cache_key(*args, **kwargs)
                     rv = self.cache.get(cache_key)
                 except Exception:
-                    if current_app.debug:
+                    if not self._ignore_backends_errors:
                         raise
                     logger.exception("Exception possibly due to cache backend.")
                     return f(*args, **kwargs)
@@ -299,7 +302,7 @@ class Cache(object):
                         self.cache.set(cache_key, rv,
                                    timeout=decorated_function.cache_timeout)
                     except Exception:
-                        if current_app.debug:
+                        if not self._ignore_backends_errors:
                             raise
                         logger.exception("Exception possibly due to cache backend.")
                         return f(*args, **kwargs)
@@ -528,7 +531,7 @@ class Cache(object):
                     cache_key = decorated_function.make_cache_key(f, *args, **kwargs)
                     rv = self.cache.get(cache_key)
                 except Exception:
-                    if current_app.debug:
+                    if not self._ignore_backends_errors:
                         raise
                     logger.exception("Exception possibly due to cache backend.")
                     return f(*args, **kwargs)
@@ -539,7 +542,7 @@ class Cache(object):
                         self.cache.set(cache_key, rv,
                                    timeout=decorated_function.cache_timeout)
                     except Exception:
-                        if current_app.debug:
+                        if not self._ignore_backends_errors:
                             raise
                         logger.exception("Exception possibly due to cache backend.")
                 return rv
@@ -666,7 +669,7 @@ class Cache(object):
                 cache_key = f.make_cache_key(f.uncached, *args, **kwargs)
                 self.cache.delete(cache_key)
         except Exception:
-            if current_app.debug:
+            if not self._ignore_backends_errors:
                 raise
             logger.exception("Exception possibly due to cache backend.")
 
@@ -689,6 +692,6 @@ class Cache(object):
         try:
             self._memoize_version(f, delete=True)
         except Exception:
-            if current_app.debug:
+            if not self._ignore_backends_errors:
                 raise
             logger.exception("Exception possibly due to cache backend.")


### PR DESCRIPTION
Right now when the app is in debug mode, backend exceptions get
re-raised; this change adds the possibility to override this by using
the setting CACHE_IGNORE_BACKEND_ERRORS. This defaults to the inverse of
app.debug, to maintain current functionality.
