### PR TITLE
fix bugs if function with only kwargs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ docs/_build/*
 Flask_Cache.egg-info/*
 build/*
 dist/
+.idea/

--- a/flask_cache/__init__.py
+++ b/flask_cache/__init__.py
@@ -418,46 +418,56 @@ class Cache(object):
         argspec = inspect.getargspec(f)
 
         args_len = len(argspec.args)
-        for i in range(args_len):
-            if i == 0 and argspec.args[i] in ('self', 'cls'):
-                #: use the repr of the class instance
-                #: this supports instance methods for
-                #: the memoized functions, giving more
-                #: flexibility to developers
-                arg = repr(args[0])
-                arg_num += 1
-            elif argspec.args[i] in kwargs:
-                arg = kwargs[argspec.args[i]]
-            elif arg_num < len(args):
-                arg = args[arg_num]
-                arg_num += 1
-            elif abs(i-args_len) <= len(argspec.defaults):
-                arg = argspec.defaults[i-args_len]
-                arg_num += 1
-            else:
-                arg = None
-                arg_num += 1
+        if args_len:
+            for i in range(args_len):
+                if i == 0 and argspec.args[i] in ('self', 'cls'):
+                    #: use the repr of the class instance
+                    #: this supports instance methods for
+                    #: the memoized functions, giving more
+                    #: flexibility to developers
+                    arg = repr(args[0])
+                    arg_num += 1
+                elif argspec.args[i] in kwargs:
+                    arg = kwargs[argspec.args[i]]
+                elif arg_num < len(args):
+                    arg = args[arg_num]
+                    arg_num += 1
+                elif abs(i-args_len) <= len(argspec.defaults):
+                    arg = argspec.defaults[i-args_len]
+                    arg_num += 1
+                else:
+                    arg = None
+                    arg_num += 1
 
-            #: Attempt to convert all arguments to a
-            #: hash/id or a representation?
-            #: Not sure if this is necessary, since
-            #: using objects as keys gets tricky quickly.
-            # if hasattr(arg, '__class__'):
-            #     try:
-            #         arg = hash(arg)
-            #     except:
-            #         arg = repr(arg)
+                #: Attempt to convert all arguments to a
+                #: hash/id or a representation?
+                #: Not sure if this is necessary, since
+                #: using objects as keys gets tricky quickly.
+                # if hasattr(arg, '__class__'):
+                #     try:
+                #         arg = hash(arg)
+                #     except:
+                #         arg = repr(arg)
 
-            #: Or what about a special __cacherepr__ function
-            #: on an object, this allows objects to act normal
-            #: upon inspection, yet they can define a representation
-            #: that can be used to make the object unique in the
-            #: cache key. Given that a case comes across that
-            #: an object "must" be used as a cache key
-            # if hasattr(arg, '__cacherepr__'):
-            #     arg = arg.__cacherepr__
+                #: Or what about a special __cacherepr__ function
+                #: on an object, this allows objects to act normal
+                #: upon inspection, yet they can define a representation
+                #: that can be used to make the object unique in the
+                #: cache key. Given that a case comes across that
+                #: an object "must" be used as a cache key
+                # if hasattr(arg, '__cacherepr__'):
+                #     arg = arg.__cacherepr__
 
-            new_args.append(arg)
+                new_args.append(arg)
+        else:
+            # if function like this
+            # @cache.memoize(timeout=60)
+            # def foo(**kwargs):
+            #     print kwargs
+
+            if len(kwargs) > 0:
+                for k, v in kwargs.items():
+                    new_args.append(v)
 
         return tuple(new_args), {}
 


### PR DESCRIPTION
when function only with kwargs
As shown below.

```bash
$ cat test.py 
from flask import Flask
from flask_cache import Cache

app = Flask(__name__)
cache = Cache(config={'CACHE_TYPE': 'simple'})
cache.init_app(app)

@cache.memoize(timeout=120)
def foo(**kwargs):
    return str(kwargs)

@app.route('/')
def index():
    st = foo(a=1, b=2)
    st2 = foo(a=3, b=4)
    print 'st:%s , st2:%s ' % (st, st2)
    return '<html><h1>st:%s, st2:%s</h1></html>' % (st, st2)

if __name__ == '__main__':
    app.run(host='192.168.249.169', port=5000)

# run this demo
$ python test.py runserver
 * Running on http://192.168.249.169:5000/ (Press CTRL+C to quit)
st:{'a': 1, 'b': 2} , st2:{'a': 1, 'b': 2} 
172.16.84.9 - - [30/Nov/2017 20:58:59] "GET / HTTP/1.1" 200 -
```
The result is not what we want.
when i modify the code, The running results are shown below
```bash
$ python test.py runserver
 * Running on http://192.168.249.169:5000/ (Press CTRL+C to quit)
st:{'a': 1, 'b': 2} , st2:{'a': 3, 'b': 4} 
```