### PR TITLE
fix "No module named 'flask.ext'" in Python3.6

### DIFF
--- a/flask_cache/jinja2ext.py
+++ b/flask_cache/jinja2ext.py
@@ -30,7 +30,7 @@ Example:
 
 from jinja2 import nodes
 from jinja2.ext import Extension
-from flask.ext.cache import make_template_fragment_key
+from flask_cache import make_template_fragment_key
 
 JINJA_CACHE_ATTR_NAME = '_template_fragment_cache'
 


### PR DESCRIPTION
Traceback (most recent call last):
  File "/manage.py", line 5, in <module>
    from gBlockChain import app
  File "/gBlockChain/__init__.py", line 116, in <module>
    register_extensions(app)
  File "/gBlockChain/utils.py", line 39, in __deco
    f(*args, **kwargs)
  File "/gBlockChain/__init__.py", line 32, in register_extensions
    getattr(kw['module'].extension, 'init_app')(app)
  File "/gBlockChain/extensions/redis.py", line 16, in init_app
    super(NewCache, self).init_app(app, config_cache)
  File "/usr/local/lib/python3.6/site-packages/flask_cache/__init__.py", line 156, in init_app
    from .jinja2ext import CacheExtension, JINJA_CACHE_ATTR_NAME
  File "/usr/local/lib/python3.6/site-packages/flask_cache/jinja2ext.py", line 33, in <module>
    from flask.ext.cache import make_template_fragment_key
ModuleNotFoundError: No module named 'flask.ext'