### PR TITLE
Update jinja2ext.py

### DIFF
--- a/flask_cache/jinja2ext.py
+++ b/flask_cache/jinja2ext.py
@@ -30,7 +30,7 @@ Example:
 
 from jinja2 import nodes
 from jinja2.ext import Extension
-from flask.ext.cache import make_template_fragment_key
+from flask_cache import make_template_fragment_key
 
 JINJA_CACHE_ATTR_NAME = '_template_fragment_cache'
 


### PR DESCRIPTION
The import statement flask.ext.cache is not supported in flask 1.0. So updated it to flask_cache which ran successfully in my application.