### PR TITLE
Use cachelib instead of werkzueg contrib.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,17 @@
 Changelog
 ---------
 
+Version 0.14 2019-05-21
+```````````````````````
+
+- Update imports to use modern flask style for extensions.
+- Reference cachelib since werkzeug removed the contrib.
+- Code style fixes.
+- Remove GAEMemcache since cachelib does not support it.
+  (Might add it to cachelib, might not I don't use it.
+   Is it really different than normal memcached?)
+- Fix import_string import from werkzeug.
+
 Version 0.13 2014-04-21
 ```````````````````````
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -7,3 +7,4 @@ dahlia (Hong Minhee)
 jab (Joshua Bronson)
 kennethreitz (Kenneth Reitz)
 Thomas Waldmann
+Bill Schumacher

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,7 +20,7 @@ Set Up
 Cache is managed through a ``Cache`` instance::
 
     from flask import Flask
-    from flask.ext.cache import Cache
+    from flask_cache import Cache
 
     app = Flask(__name__)
     # Check Configuring Flask-Cache section for more details
@@ -243,7 +243,7 @@ The following configuration values exist for Flask-Cache:
                                 * **null**: NullCache (default)
                                 * **simple**: SimpleCache
                                 * **memcached**: MemcachedCache (pylibmc or memcache required)
-                                * **gaememcached**: GAEMemcachedCache
+                                * **gaememcached**: GAEMemcachedCache !!! Removed temporarily?
                                 * **redis**: RedisCache (Werkzeug 0.7 required)
                                 * **filesystem**: FileSystemCache
                                 * **saslmemcached**: SASLMemcachedCache (pylibmc required)
@@ -340,7 +340,7 @@ Relevant configuration values
 
 GAEMemcachedCache -- gaememcached
 `````````````````````````````````
-
+!!! Removed in 0.14, is it really different than memcached?
 Is MemcachedCache under a different name
 
 SASLMemcachedCache -- saslmemcached

--- a/examples/hello.py
+++ b/examples/hello.py
@@ -2,7 +2,7 @@ import random
 from datetime import datetime
 
 from flask import Flask, jsonify
-from flask.ext.cache import Cache
+from flask_cache import Cache
 
 
 app = Flask(__name__)

--- a/flask_cache/__init__.py
+++ b/flask_cache/__init__.py
@@ -9,7 +9,7 @@
     :license: BSD, see LICENSE for more details
 """
 
-__version__ = '0.13'
+__version__ = '0.13a'
 __versionfull__ = __version__
 
 import base64
@@ -21,7 +21,7 @@ import string
 import uuid
 import warnings
 
-from werkzeug import import_string
+from werkzeug.utils import import_string
 from flask import request, current_app
 
 from ._compat import PY2
@@ -36,7 +36,8 @@ delchars = ''.join(c for c in map(chr, range(256)) if c not in valid_chars)
 if PY2:
     null_control = (None, delchars)
 else:
-    null_control = (dict((k,None) for k in delchars),)
+    null_control = (dict((k, None) for k in delchars),)
+
 
 def function_namespace(f, args=None):
     """
@@ -48,11 +49,11 @@ def function_namespace(f, args=None):
     instance_self = getattr(f, '__self__', None)
 
     if instance_self \
-    and not inspect.isclass(instance_self):
+            and not inspect.isclass(instance_self):
         instance_token = repr(f.__self__)
     elif m_args \
-    and m_args[0] == 'self' \
-    and args:
+            and m_args[0] == 'self' \
+            and args:
         instance_token = repr(args[0])
 
     module = f.__module__
@@ -63,7 +64,7 @@ def function_namespace(f, args=None):
         klass = getattr(f, '__self__', None)
 
         if klass \
-        and not inspect.isclass(klass):
+                and not inspect.isclass(klass):
             klass = klass.__class__
 
         if not klass:
@@ -91,6 +92,7 @@ def function_namespace(f, args=None):
         ins = None
 
     return ns, ins
+
 
 def make_template_fragment_key(fragment_name, vary_on=[]):
     """
@@ -169,7 +171,7 @@ class Cache(object):
                 cache_obj = getattr(backends, import_me)
             except AttributeError:
                 raise ImportError("%s is not a valid FlaskCache backend" % (
-                                  import_me))
+                    import_me))
         else:
             cache_obj = import_string(import_me)
 
@@ -184,7 +186,7 @@ class Cache(object):
 
         app.extensions.setdefault('cache', {})
         app.extensions['cache'][self] = cache_obj(
-                app, config, cache_args, cache_options)
+            app, config, cache_args, cache_options)
 
     @property
     def cache(self):
@@ -297,7 +299,7 @@ class Cache(object):
                     rv = f(*args, **kwargs)
                     try:
                         self.cache.set(cache_key, rv,
-                                   timeout=decorated_function.cache_timeout)
+                                       timeout=decorated_function.cache_timeout)
                     except Exception:
                         if current_app.debug:
                             raise
@@ -320,6 +322,7 @@ class Cache(object):
             decorated_function.make_cache_key = make_cache_key
 
             return decorated_function
+
         return decorator
 
     def _memvname(self, funcname):
@@ -375,6 +378,7 @@ class Cache(object):
         """
         Function used to create the cache_key for memoized functions.
         """
+
         def make_cache_key(f, *args, **kwargs):
             _timeout = getattr(timeout, 'cache_timeout', timeout)
             fname, version_data = self._memoize_version(f, args=args,
@@ -389,8 +393,8 @@ class Cache(object):
 
             if callable(f):
                 keyargs, keykwargs = self._memoize_kwargs_to_args(f,
-                                                                 *args,
-                                                                 **kwargs)
+                                                                  *args,
+                                                                  **kwargs)
             else:
                 keyargs, keykwargs = args, kwargs
 
@@ -406,6 +410,7 @@ class Cache(object):
             cache_key += version_data
 
             return cache_key
+
         return make_cache_key
 
     def _memoize_kwargs_to_args(self, f, *args, **kwargs):
@@ -431,8 +436,8 @@ class Cache(object):
             elif arg_num < len(args):
                 arg = args[arg_num]
                 arg_num += 1
-            elif abs(i-args_len) <= len(argspec.defaults):
-                arg = argspec.defaults[i-args_len]
+            elif abs(i - args_len) <= len(argspec.defaults):
+                arg = argspec.defaults[i - args_len]
                 arg_num += 1
             else:
                 arg = None
@@ -537,7 +542,7 @@ class Cache(object):
                     rv = f(*args, **kwargs)
                     try:
                         self.cache.set(cache_key, rv,
-                                   timeout=decorated_function.cache_timeout)
+                                       timeout=decorated_function.cache_timeout)
                     except Exception:
                         if current_app.debug:
                             raise
@@ -547,10 +552,11 @@ class Cache(object):
             decorated_function.uncached = f
             decorated_function.cache_timeout = timeout
             decorated_function.make_cache_key = self._memoize_make_cache_key(
-                                                make_name, decorated_function)
+                make_name, decorated_function)
             decorated_function.delete_memoized = lambda: self.delete_memoized(f)
 
             return decorated_function
+
         return memoize
 
     def delete_memoized(self, f, *args, **kwargs):
@@ -656,8 +662,7 @@ class Cache(object):
         """
         if not callable(f):
             raise DeprecationWarning("Deleting messages by relative name is no longer"
-                          " reliable, please switch to a function reference")
-
+                                     " reliable, please switch to a function reference")
 
         try:
             if not args and not kwargs:
@@ -684,7 +689,7 @@ class Cache(object):
         """
         if not callable(f):
             raise DeprecationWarning("Deleting messages by relative name is no longer"
-                          " reliable, please use a function reference")
+                                     " reliable, please use a function reference")
 
         try:
             self._memoize_version(f, delete=True)

--- a/flask_cache/_compat.py
+++ b/flask_cache/_compat.py
@@ -15,7 +15,6 @@ import sys
 PY2 = sys.version_info[0] == 2
 PYPY = hasattr(sys, 'pypy_translation_info')
 
-
 if not PY2:
     range_type = range
 else:

--- a/flask_cache/jinja2ext.py
+++ b/flask_cache/jinja2ext.py
@@ -30,7 +30,7 @@ Example:
 
 from jinja2 import nodes
 from jinja2.ext import Extension
-from flask.ext.cache import make_template_fragment_key
+from flask_cache import make_template_fragment_key
 
 JINJA_CACHE_ATTR_NAME = '_template_fragment_cache'
 
@@ -67,7 +67,7 @@ class CacheExtension(Extension):
         return nodes.CallBlock(self.call_method('_cache', args),
                                [], [], body).set_lineno(lineno)
 
-    def _cache(self, timeout, fragment_name, vary_on,  caller):
+    def _cache(self, timeout, fragment_name, vary_on, caller):
         try:
             cache = getattr(self.environment, JINJA_CACHE_ATTR_NAME)
         except AttributeError as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 git+git://github.com/mitsuhiko/werkzeug.git#egg=werkzeug
 git+git://github.com/mitsuhiko/flask.git#egg=flask
+git+git://github.com/pallets/cachelib.git#egg=cachelib

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup
 
 setup(
     name='Flask-Cache',
-    version='0.13',
+    version='0.14',
     url='http://github.com/thadeusb/flask-cache',
     license='BSD',
     author='Thadeus Burgess',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     zip_safe=False,
     platforms='any',
     install_requires=[
-        'Flask'
+        'Flask', 'cachelib'
     ],
     test_suite='test_cache',
     classifiers=[

--- a/test_cache.py
+++ b/test_cache.py
@@ -7,12 +7,13 @@ import random
 import string
 
 from flask import Flask, render_template, render_template_string
-from flask.ext.cache import Cache, function_namespace, make_template_fragment_key
+from flask_cache import Cache, function_namespace, make_template_fragment_key
 
-if sys.version_info < (2,7):
+if sys.version_info < (2, 7):
     import unittest2 as unittest
 else:
     import unittest
+
 
 class CacheTestCase(unittest.TestCase):
 
@@ -130,7 +131,7 @@ class CacheTestCase(unittest.TestCase):
         with self.app.test_request_context():
             @self.cache.memoize(5)
             def big_foo(a, b):
-                return a+b+random.randrange(0, 100000)
+                return a + b + random.randrange(0, 100000)
 
             result = big_foo(5, 2)
 
@@ -156,7 +157,7 @@ class CacheTestCase(unittest.TestCase):
         with self.app.test_request_context():
             @self.cache.memoize(50)
             def big_foo(a, b):
-                return a+b+random.randrange(0, 100000)
+                return a + b + random.randrange(0, 100000)
 
             result = big_foo(5, 2)
 
@@ -169,7 +170,7 @@ class CacheTestCase(unittest.TestCase):
         with self.app.test_request_context():
             @self.cache.memoize(5)
             def big_foo(a, b):
-                return a+b+random.randrange(0, 100000)
+                return a + b + random.randrange(0, 100000)
 
             result = big_foo(5, 2)
             result2 = big_foo(5, 3)
@@ -190,7 +191,7 @@ class CacheTestCase(unittest.TestCase):
         with self.app.test_request_context():
             @self.cache.memoize(5)
             def big_foo(a, b):
-                return a+b+random.randrange(0, 100000)
+                return a + b + random.randrange(0, 100000)
 
             result = big_foo(5, 2)
             result2 = big_foo(5, 3)
@@ -218,7 +219,7 @@ class CacheTestCase(unittest.TestCase):
         with self.app.test_request_context():
             @self.cache.memoize()
             def big_foo(a, b):
-                return a+b+random.randrange(0, 100000)
+                return a + b + random.randrange(0, 100000)
 
             result_a = big_foo(5, 1)
             result_b = big_foo(5, 2)
@@ -240,41 +241,41 @@ class CacheTestCase(unittest.TestCase):
         with self.app.test_request_context():
             @self.cache.memoize()
             def big_foo(a, b):
-                return sum(a)+sum(b)+random.randrange(0, 100000)
+                return sum(a) + sum(b) + random.randrange(0, 100000)
 
-            result_a = big_foo([5,3,2], [1])
-            result_b = big_foo([3,3], [3,1])
+            result_a = big_foo([5, 3, 2], [1])
+            result_b = big_foo([3, 3], [3, 1])
 
-            assert big_foo([5,3,2], [1]) == result_a
-            assert big_foo([3,3], [3,1]) == result_b
+            assert big_foo([5, 3, 2], [1]) == result_a
+            assert big_foo([3, 3], [3, 1]) == result_b
 
-            self.cache.delete_memoized(big_foo, [5,3,2], [1])
+            self.cache.delete_memoized(big_foo, [5, 3, 2], [1])
 
-            assert big_foo([5,3,2], [1]) != result_a
-            assert big_foo([3,3], [3,1]) == result_b
+            assert big_foo([5, 3, 2], [1]) != result_a
+            assert big_foo([3, 3], [3, 1]) == result_b
 
             ## Cleanup bigfoo 5,1 5,2 or it might conflict with
             ## following run if it also uses memecache
-            self.cache.delete_memoized(big_foo, [5,3,2], [1])
-            self.cache.delete_memoized(big_foo, [3,3], [1])
+            self.cache.delete_memoized(big_foo, [5, 3, 2], [1])
+            self.cache.delete_memoized(big_foo, [3, 3], [1])
 
     def test_10_kwargs_memoize(self):
 
         with self.app.test_request_context():
             @self.cache.memoize()
             def big_foo(a, b=None):
-                return a+sum(b.values())+random.randrange(0, 100000)
+                return a + sum(b.values()) + random.randrange(0, 100000)
 
-            result_a = big_foo(1, dict(one=1,two=2))
-            result_b = big_foo(5, dict(three=3,four=4))
+            result_a = big_foo(1, dict(one=1, two=2))
+            result_b = big_foo(5, dict(three=3, four=4))
 
-            assert big_foo(1, dict(one=1,two=2)) == result_a
-            assert big_foo(5, dict(three=3,four=4)) == result_b
+            assert big_foo(1, dict(one=1, two=2)) == result_a
+            assert big_foo(5, dict(three=3, four=4)) == result_b
 
-            self.cache.delete_memoized(big_foo, 1, dict(one=1,two=2))
+            self.cache.delete_memoized(big_foo, 1, dict(one=1, two=2))
 
-            assert big_foo(1, dict(one=1,two=2)) != result_a
-            assert big_foo(5, dict(three=3,four=4)) == result_b
+            assert big_foo(1, dict(one=1, two=2)) != result_a
+            assert big_foo(5, dict(three=3, four=4)) == result_b
 
     def test_10a_kwargonly_memoize(self):
 
@@ -283,7 +284,7 @@ class CacheTestCase(unittest.TestCase):
             def big_foo(a=None):
                 if a is None:
                     a = 0
-                return a+random.random()
+                return a + random.random()
 
             result_a = big_foo()
             result_b = big_foo(5)
@@ -297,12 +298,12 @@ class CacheTestCase(unittest.TestCase):
         with self.app.test_request_context():
             @self.cache.memoize()
             def f(a, b, c=1):
-                return a+b+c+random.randrange(0, 100000)
+                return a + b + c + random.randrange(0, 100000)
 
-            assert f(1,2) == f(1,2,c=1)
-            assert f(1,2) == f(1,2,1)
-            assert f(1,2) == f(1,2)
-            assert f(1,2,3) != f(1,2)
+            assert f(1, 2) == f(1, 2, c=1)
+            assert f(1, 2) == f(1, 2, 1)
+            assert f(1, 2) == f(1, 2)
+            assert f(1, 2, 3) != f(1, 2)
             with self.assertRaises(TypeError):
                 f(1)
 
@@ -393,7 +394,7 @@ class CacheTestCase(unittest.TestCase):
                 @classmethod
                 @self.cache.memoize(5)
                 def big_foo(cls, a, b):
-                    return a+b+random.randrange(0, 100000)
+                    return a + b + random.randrange(0, 100000)
 
             result = Mock.big_foo(5, 2)
             result2 = Mock.big_foo(5, 3)
@@ -498,62 +499,62 @@ class CacheTestCase(unittest.TestCase):
     def test_14_memoized_multiple_arg_kwarg_calls(self):
         with self.app.test_request_context():
             @self.cache.memoize()
-            def big_foo(a, b,c=[1,1],d=[1,1]):
-                return sum(a)+sum(b)+sum(c)+sum(d)+random.randrange(0, 100000)
+            def big_foo(a, b, c=[1, 1], d=[1, 1]):
+                return sum(a) + sum(b) + sum(c) + sum(d) + random.randrange(0, 100000)
 
-            result_a = big_foo([5,3,2], [1], c=[3,3], d=[3,3])
+            result_a = big_foo([5, 3, 2], [1], c=[3, 3], d=[3, 3])
 
-            assert big_foo([5,3,2], [1], d=[3,3], c=[3,3]) == result_a
-            assert big_foo(b=[1],a=[5,3,2],c=[3,3],d=[3,3]) == result_a
-            assert big_foo([5,3,2], [1], [3,3], [3,3]) == result_a
+            assert big_foo([5, 3, 2], [1], d=[3, 3], c=[3, 3]) == result_a
+            assert big_foo(b=[1], a=[5, 3, 2], c=[3, 3], d=[3, 3]) == result_a
+            assert big_foo([5, 3, 2], [1], [3, 3], [3, 3]) == result_a
 
     def test_15_memoize_multiple_arg_kwarg_delete(self):
         with self.app.test_request_context():
             @self.cache.memoize()
-            def big_foo(a, b,c=[1,1],d=[1,1]):
-                return sum(a)+sum(b)+sum(c)+sum(d)+random.randrange(0, 100000)
+            def big_foo(a, b, c=[1, 1], d=[1, 1]):
+                return sum(a) + sum(b) + sum(c) + sum(d) + random.randrange(0, 100000)
 
-            result_a = big_foo([5,3,2], [1], c=[3,3], d=[3,3])
-            self.cache.delete_memoized(big_foo, [5,3,2],[1],[3,3],[3,3])
-            result_b = big_foo([5,3,2], [1], c=[3,3], d=[3,3])
+            result_a = big_foo([5, 3, 2], [1], c=[3, 3], d=[3, 3])
+            self.cache.delete_memoized(big_foo, [5, 3, 2], [1], [3, 3], [3, 3])
+            result_b = big_foo([5, 3, 2], [1], c=[3, 3], d=[3, 3])
             assert result_a != result_b
 
-            self.cache.delete_memoized(big_foo, [5,3,2],b=[1],c=[3,3],d=[3,3])
-            result_b = big_foo([5,3,2], [1], c=[3,3], d=[3,3])
+            self.cache.delete_memoized(big_foo, [5, 3, 2], b=[1], c=[3, 3], d=[3, 3])
+            result_b = big_foo([5, 3, 2], [1], c=[3, 3], d=[3, 3])
             assert result_a != result_b
 
-            self.cache.delete_memoized(big_foo, [5,3,2],[1],c=[3,3],d=[3,3])
-            result_a = big_foo([5,3,2], [1], c=[3,3], d=[3,3])
+            self.cache.delete_memoized(big_foo, [5, 3, 2], [1], c=[3, 3], d=[3, 3])
+            result_a = big_foo([5, 3, 2], [1], c=[3, 3], d=[3, 3])
             assert result_a != result_b
 
-            self.cache.delete_memoized(big_foo, [5,3,2],b=[1],c=[3,3],d=[3,3])
-            result_a = big_foo([5,3,2], [1], c=[3,3], d=[3,3])
+            self.cache.delete_memoized(big_foo, [5, 3, 2], b=[1], c=[3, 3], d=[3, 3])
+            result_a = big_foo([5, 3, 2], [1], c=[3, 3], d=[3, 3])
             assert result_a != result_b
 
-            self.cache.delete_memoized(big_foo, [5,3,2],[1],c=[3,3],d=[3,3])
-            result_b = big_foo([5,3,2], [1], c=[3,3], d=[3,3])
+            self.cache.delete_memoized(big_foo, [5, 3, 2], [1], c=[3, 3], d=[3, 3])
+            result_b = big_foo([5, 3, 2], [1], c=[3, 3], d=[3, 3])
             assert result_a != result_b
 
-            self.cache.delete_memoized(big_foo, [5,3,2],[1],[3,3],[3,3])
-            result_a = big_foo([5,3,2], [1], c=[3,3], d=[3,3])
+            self.cache.delete_memoized(big_foo, [5, 3, 2], [1], [3, 3], [3, 3])
+            result_a = big_foo([5, 3, 2], [1], c=[3, 3], d=[3, 3])
             assert result_a != result_b
 
     def test_16_memoize_kwargs_to_args(self):
         with self.app.test_request_context():
             def big_foo(a, b, c=None, d=None):
-                return sum(a)+sum(b)+random.randrange(0, 100000)
+                return sum(a) + sum(b) + random.randrange(0, 100000)
 
-            expected = (1,2,'foo','bar')
+            expected = (1, 2, 'foo', 'bar')
 
-            args, kwargs = self.cache._memoize_kwargs_to_args(big_foo, 1,2,'foo','bar')
+            args, kwargs = self.cache._memoize_kwargs_to_args(big_foo, 1, 2, 'foo', 'bar')
             assert (args == expected)
-            args, kwargs = self.cache._memoize_kwargs_to_args(big_foo, 2,'foo','bar',a=1)
+            args, kwargs = self.cache._memoize_kwargs_to_args(big_foo, 2, 'foo', 'bar', a=1)
             assert (args == expected)
-            args, kwargs = self.cache._memoize_kwargs_to_args(big_foo, a=1,b=2,c='foo',d='bar')
+            args, kwargs = self.cache._memoize_kwargs_to_args(big_foo, a=1, b=2, c='foo', d='bar')
             assert (args == expected)
-            args, kwargs = self.cache._memoize_kwargs_to_args(big_foo, d='bar',b=2,a=1,c='foo')
+            args, kwargs = self.cache._memoize_kwargs_to_args(big_foo, d='bar', b=2, a=1, c='foo')
             assert (args == expected)
-            args, kwargs = self.cache._memoize_kwargs_to_args(big_foo, 1,2,d='bar',c='foo')
+            args, kwargs = self.cache._memoize_kwargs_to_args(big_foo, 1, 2, d='bar', c='foo')
             assert (args == expected)
 
     def test_17_dict_config(self):
@@ -565,13 +566,13 @@ class CacheTestCase(unittest.TestCase):
     def test_18_dict_config_initapp(self):
         cache = Cache()
         cache.init_app(self.app, config={'CACHE_TYPE': 'simple'})
-        from werkzeug.contrib.cache import SimpleCache
+        from cachelib import SimpleCache
         assert isinstance(self.app.extensions['cache'][cache], SimpleCache)
 
     def test_19_dict_config_both(self):
         cache = Cache(config={'CACHE_TYPE': 'null'})
         cache.init_app(self.app, config={'CACHE_TYPE': 'simple'})
-        from werkzeug.contrib.cache import SimpleCache
+        from cachelib import SimpleCache
         assert isinstance(self.app.extensions['cache'][cache], SimpleCache)
 
     def test_20_jinja2ext_cache(self):
@@ -623,15 +624,16 @@ class CacheTestCase(unittest.TestCase):
 if 'TRAVIS' in os.environ:
     try:
         import redis
+
         has_redis = True
     except ImportError:
         has_redis = False
 
-    if sys.version_info <= (2,7):
-
+    if sys.version_info <= (2, 7):
         class CacheMemcachedTestCase(CacheTestCase):
             def _set_app_config(self, app):
                 app.config['CACHE_TYPE'] = 'memcached'
+
 
         class SpreadCacheMemcachedTestCase(CacheTestCase):
             def _set_app_config(self, app):
@@ -653,7 +655,7 @@ if 'TRAVIS' in os.environ:
             from werkzeug.contrib.cache import RedisCache
             assert isinstance(self.app.extensions['cache'][cache], RedisCache)
             rconn = self.app.extensions['cache'][cache] \
-                        ._client.connection_pool.get_connection('foo')
+                ._client.connection_pool.get_connection('foo')
             assert rconn.db == 0
 
         @unittest.skipUnless(has_redis, "requires Redis")
@@ -665,7 +667,7 @@ if 'TRAVIS' in os.environ:
             cache = Cache()
             cache.init_app(self.app, config=config)
             rconn = self.app.extensions['cache'][cache] \
-                        ._client.connection_pool.get_connection('foo')
+                ._client.connection_pool.get_connection('foo')
             assert rconn.db == 2
 
         @unittest.skipUnless(has_redis, "requires Redis")
@@ -678,7 +680,7 @@ if 'TRAVIS' in os.environ:
             cache = Cache()
             cache.init_app(self.app, config=config)
             rconn = self.app.extensions['cache'][cache] \
-                        ._client.connection_pool.get_connection('foo')
+                ._client.connection_pool.get_connection('foo')
             assert rconn.db == 1
 
 
@@ -686,7 +688,6 @@ if 'TRAVIS' in os.environ:
         def _set_app_config(self, app):
             app.config['CACHE_TYPE'] = 'filesystem'
             app.config['CACHE_DIR'] = '/tmp'
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I see that many people have PRs open, one more for good measure.

- Update imports to use modern flask style for extensions.
- Reference cachelib since werkzeug removed the contrib.
- Code style fixes.
- Remove GAEMemcache since cachelib does not support it.
  (Might add it to cachelib, might not I don't use it.
   Is it really different than normal memcached?)
- Fix import_string import from werkzeug.

